### PR TITLE
#125 ActiveDirectoryの場合のLdapログインの対策

### DIFF
--- a/src/main/java/org/support/project/web/dao/UsersDao.java
+++ b/src/main/java/org/support/project/web/dao/UsersDao.java
@@ -95,6 +95,19 @@ public class UsersDao extends GenUsersDao {
 		String sql = "SELECT * FROM USERS WHERE USER_KEY = ?;";
 		return executeQuerySingle(sql, UsersEntity.class, userKey);
 	}
+	/**
+	 * ユーザのキーでユーザ情報を取得
+	 * キーは小文字にして取得する（ActiveDirectoryでは、IDは大文字・小文字を判別しない）
+	 * @param userKey
+	 * @return
+	 */
+	public UsersEntity selectOnLowerUserKey(String userKey) {
+		if (StringUtils.isEmpty(userKey)) {
+			return null;
+		}
+		String sql = "SELECT * FROM USERS WHERE LOWER(USER_KEY) = ?;";
+		return executeQuerySingle(sql, UsersEntity.class, userKey.toLowerCase());
+	}
 
 	/**
 	 * ロールIDを指定してユーザ情報を取得

--- a/src/main/java/org/support/project/web/filter/AuthenticationFilter.java
+++ b/src/main/java/org/support/project/web/filter/AuthenticationFilter.java
@@ -360,23 +360,23 @@ public class AuthenticationFilter implements Filter {
 	 * @throws Exception 
 	 */
 	protected boolean doLogin(HttpServletRequest req) throws Exception {
-		String username = req.getParameter("username");
+		String userkey = req.getParameter("username");
 		String password = req.getParameter("password");
 		
-		if (authenticationLogic.auth(username, password)) {
+		if (authenticationLogic.auth(userkey, password)) {
 			// セッションにログイン情報を格納
-			LOG.info(username + " is Login.");
+			LOG.info(userkey + " is Login.");
 			
 			// ActiveDirectoryでは、ログインIDは大文字・小文字を判定しないので、DBに格納されているIDを取得
-			UsersEntity usersEntity = UsersDao.get().selectOnLowerUserKey(username);
+			UsersEntity usersEntity = UsersDao.get().selectOnLowerUserKey(userkey);
 			if (usersEntity == null) {
 				// なぜかユーザ情報が無い
 				return false;
 			}
-			if (!username.equals(usersEntity.getUserKey())) {
-				username = usersEntity.getUserKey();
+			if (!userkey.equals(usersEntity.getUserKey())) {
+				userkey = usersEntity.getUserKey();
 			}
-			authenticationLogic.setSession(username, req);
+			authenticationLogic.setSession(userkey, req);
 			return true;
 		}
 		return false;

--- a/src/main/java/org/support/project/web/filter/AuthenticationFilter.java
+++ b/src/main/java/org/support/project/web/filter/AuthenticationFilter.java
@@ -31,6 +31,8 @@ import org.support.project.web.bean.LoginedUser;
 import org.support.project.web.common.HttpStatus;
 import org.support.project.web.common.HttpUtil;
 import org.support.project.web.config.CommonWebParameter;
+import org.support.project.web.dao.UsersDao;
+import org.support.project.web.entity.UsersEntity;
 import org.support.project.web.exception.AuthenticateException;
 import org.support.project.web.logic.AuthenticationLogic;
 import org.support.project.web.wrapper.HttpServletRequestWrapper;
@@ -364,6 +366,16 @@ public class AuthenticationFilter implements Filter {
 		if (authenticationLogic.auth(username, password)) {
 			// セッションにログイン情報を格納
 			LOG.info(username + " is Login.");
+			
+			// ActiveDirectoryでは、ログインIDは大文字・小文字を判定しないので、DBに格納されているIDを取得
+			UsersEntity usersEntity = UsersDao.get().selectOnLowerUserKey(username);
+			if (usersEntity == null) {
+				// なぜかユーザ情報が無い
+				return false;
+			}
+			if (!username.equals(usersEntity.getUserKey())) {
+				username = usersEntity.getUserKey();
+			}
 			authenticationLogic.setSession(username, req);
 			return true;
 		}

--- a/src/main/java/org/support/project/web/logic/impl/DefaultAuthenticationLogicImpl.java
+++ b/src/main/java/org/support/project/web/logic/impl/DefaultAuthenticationLogicImpl.java
@@ -55,7 +55,7 @@ public class DefaultAuthenticationLogicImpl extends AbstractAuthenticationLogic<
 					if (ldapInfo != null) {
 						// Ldap認証成功
 						UsersDao usersDao = UsersDao.get();
-						UsersEntity usersEntity = usersDao.selectOnUserKey(userId);
+						UsersEntity usersEntity = usersDao.selectOnLowerUserKey(userId);
 						if (usersEntity == null) {
 							addUser(userId, password, ldapInfo);
 						} else {


### PR DESCRIPTION
- ActiveDirectoryでLdapログインする場合、ユーザIDが大文字／小文字を判別しません
- このため、先にログインした文字と別の文字でログインするとエラーが発生する
  - e.g. 「ID1」でログインした後に、「id1」でログインするとエラー
- ログイン時に、大文字／小文字を判別しないでユーザテーブルの情報を検索し、すでに情報があるものを使うように変更
