### PR TITLE
サニタイジング処理の中でdelタグを許すように変更

### DIFF
--- a/src/main/java/org/support/project/web/logic/SanitizingLogic.java
+++ b/src/main/java/org/support/project/web/logic/SanitizingLogic.java
@@ -176,7 +176,7 @@ public class SanitizingLogic {
 			.onElements("colgroup", "col")
 			.allowElements("a", "label", "noscript", "h1", "h2", "h3", "h4", "h5", "h6", "p", "i", "b", "u", "strong", "em", "small", "big", "pre",
 					"code", "cite", "samp", "sub", "sup", "strike", "center", "blockquote", "hr", "br", "col", "font", "map", "span", "div", "img",
-					"ul", "ol", "li", "dd", "dt", "dl", "tbody", "thead", "tfoot", "table", "td", "th", "tr", "colgroup", "fieldset", "legend")
+					"ul", "ol", "li", "dd", "dt", "dl", "tbody", "thead", "tfoot", "table", "td", "th", "tr", "colgroup", "fieldset", "legend", "del")
 			.toFactory();
 	
 


### PR DESCRIPTION
Markdown処理で取り消し線の部分に、<del></del>のdelタグで囲むが、
サニタイジング処理で、そのdelタグを許していないのでdelタグを消してしまっていた。
