### PR TITLE
Fix javadoc comment for deploy to maven.

### DIFF
--- a/src/main/java/org/support/project/web/dao/UserGroupsDao.java
+++ b/src/main/java/org/support/project/web/dao/UserGroupsDao.java
@@ -32,7 +32,7 @@ public class UserGroupsDao extends GenUserGroupsDao {
     /**
      * グループのID配列からエンティティを取得する
      * 
-     * @param Integer[] groupIds
+     * @param groupIds Integer[] Group Ids
      * @return list
      */
     public List<UserGroupsEntity> selectOnGroupIds(List<Integer> groupIds) {


### PR DESCRIPTION
Maven に ライブラリを登録する際に、 javadocコメントのチェックがあり、エラーになると登録できないので修正。（警告とかは無視している）

UserGroupsDao.java:35: エラー: @param nameが見つかりません
     * @param Integer[] groupIds
