### PR TITLE
Revert "fix ldap bug"

### DIFF
--- a/src/main/java/org/support/project/web/logic/LdapLogic.java
+++ b/src/main/java/org/support/project/web/logic/LdapLogic.java
@@ -154,9 +154,8 @@ public class LdapLogic {
             SearchScope scope = SearchScope.SUBTREE;
             cursor = conn.search(base, filter, scope);
             String dn = null;
-            Entry entry = null;
             while (cursor.next()) {
-                entry = cursor.get();
+                Entry entry = cursor.get();
                 dn = entry.getDn().toString();
                 break;
             }
@@ -168,7 +167,14 @@ public class LdapLogic {
             conn2 = new LdapNetworkConnection(config);
             conn2.bind(dn, password); // Bind DN //Bind Password (接続確認用）
             
-            return loadLdapInfo(entity, entry);
+            cursor = conn2.search(base, filter, scope);
+            LdapInfo info = null;
+            while (cursor.next()) {
+                Entry entry = cursor.get();
+                info = loadLdapInfo(entity, entry);
+                break;
+            }
+            return info;
         } catch (LdapException | CursorException | InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException | IllegalBlockSizeException
                 | BadPaddingException e) {
             // 認証失敗


### PR DESCRIPTION
Reverts support-project/web#97

As a result of checking the operation, it can not be confirmed whether the password exists by using bind (dn, password) alone.

-----

動作確認したところ、bind(dn, password)だけでは、パスワードがあっているかの確認にならない。
その後の検索は必要であったため、元に戻す。
